### PR TITLE
Stop using deprecated YAML.safeLoad, and use YAML.load instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function readJSON(filepath){
 function readYAML(filepath){
 	var buffer = {};
 	try{
-		buffer = YAML.safeLoad(fs.readFileSync(filepath, { schema:YAML.DEFAULT_FULL_SCHEMA }));
+		buffer = YAML.load(fs.readFileSync(filepath, { schema:YAML.DEFAULT_FULL_SCHEMA }));
 	}catch(error){
 		console.error(error);
 	}


### PR DESCRIPTION
Hi, YAML.safeLoad is deprecated, and now causes load-gulp-config to fail.  This PR fixes this issue.